### PR TITLE
feat: Implement LLVM pass for command injection detection

### DIFF
--- a/llvm-pass/afl-demo-pass.so.cc
+++ b/llvm-pass/afl-demo-pass.so.cc
@@ -13,7 +13,7 @@
 #include <memory>
 #include <string>
 #include <fstream>
-#include <set>
+#include <set> // Required for std::set
 #include <iostream>
 
 #include "llvm/Config/llvm-config.h"
@@ -43,6 +43,14 @@
 using namespace llvm;
 
 namespace {
+
+// Define the set of sink functions
+static const std::set<std::string> sinkFunctions = {
+    "system", "popen",
+    "execl", "execv", "execle", "execve", "execlp", "execvp", "execvpe",
+    "ShellExecuteA", "ShellExecuteW",
+    "CreateProcessA", "CreateProcessW"
+};
 
 class AFLDEMOPass : public PassInfoMixin<AFLDEMOPass> {
 
@@ -80,9 +88,14 @@ llvmGetPassPluginInfo() {
 
 PreservedAnalyses AFLDEMOPass::run(Module &M, ModuleAnalysisManager &MAM) {
 
-  LLVMContext &  C = M.getContext();
-  Type *         VoidTy = Type::getVoidTy(C);
-  FunctionCallee demo_crash = M.getOrInsertFunction("__demo_crash", VoidTy);
+  LLVMContext &C = M.getContext();
+  Type *VoidTy = Type::getVoidTy(C);
+  Type *CharStarTy = Type::getInt8PtrTy(C);
+
+  // Get reference to __afl_check_cmd_injection
+  FunctionCallee check_cmd_injection = M.getOrInsertFunction(
+      "__afl_check_cmd_injection",
+      FunctionType::get(VoidTy, {CharStarTy}, false));
 
   for (auto &F : M) {
 
@@ -99,24 +112,91 @@ PreservedAnalyses AFLDEMOPass::run(Module &M, ModuleAnalysisManager &MAM) {
 
         if (CallInst *call = dyn_cast<CallInst>(&I)) {
 
-          if (GetCallInsFunctionName(call).equals("system")) {
+          llvm::StringRef calledFuncName = GetCallInsFunctionName(call);
+          std::string calledFuncNameStdStr = calledFuncName.str();
 
-            IRBuilder<> IRB(&I);
-            IRB.CreateCall(demo_crash)->setMetadata(M.getMDKindID("nosanitize"),
-                                                   MDNode::get(C, None));
+          if (sinkFunctions.count(calledFuncNameStdStr)) {
+            Value *commandArgument = nullptr;
+            unsigned argIndex = 0; // Default for system, popen
 
+            if (calledFuncNameStdStr == "system" || calledFuncNameStdStr == "popen") {
+              argIndex = 0;
+            } else if (
+                calledFuncNameStdStr == "execl" ||
+                calledFuncNameStdStr == "execv" ||
+                calledFuncNameStdStr == "execle" ||
+                calledFuncNameStdStr == "execve" ||
+                calledFuncNameStdStr == "execlp" ||
+                calledFuncNameStdStr == "execvp" ||
+                calledFuncNameStdStr == "execvpe" ||
+                calledFuncNameStdStr == "CreateProcessA" || // lpApplicationName or lpCommandLine
+                calledFuncNameStdStr == "CreateProcessW"    // lpApplicationName or lpCommandLine
+            ) {
+              // For exec*, CreateProcess*, use the first argument (path/file/lpApplicationName)
+              // or second (lpCommandLine for CreateProcess)
+              // For simplicity, let's stick to a common index if possible or make specific choices.
+              // CreateProcess lpCommandLine is arg 1. For exec* path is arg 0.
+              // The subtask said for other functions (non system/popen) use argOperand(1)
+              // For CreateProcessA/W, lpCommandLine is getArgOperand(1)
+              // For execl, the 'file' or 'path' is typically the first argument (index 0),
+              // but the prompt mentioned 'arg' as second for execl.
+              // Let's use 0 for exec* functions as 'path' or 'file' is the first argument.
+              // The prompt said: "For other functions, try to get call->getArgOperand(1) as a starting point"
+              // This was then followed by: "For exec functions, the first argument is typically path or file. Let's target the file or path argument for now."
+              // This implies arg 0 for exec*.
+              // Let's stick to the more specific information for exec* (arg 0) and CreateProcess* (arg 1).
+              // ShellExecute: lpFile (arg 1) or lpParameters (arg 3). Prompt: "Let's try to get lpParameters (the 4th argument, index 3). If it's null, then try lpFile (the 2nd argument, index 1)."
+
+              if (calledFuncNameStdStr.rfind("exec", 0) == 0) { // starts with exec
+                 if (call->getNumArgOperands() > 0) commandArgument = call->getArgOperand(0);
+              } else if (calledFuncNameStdStr.find("CreateProcess") != std::string::npos) {
+                 if (call->getNumArgOperands() > 1) commandArgument = call->getArgOperand(1); // lpCommandLine
+              } else if (calledFuncNameStdStr.find("ShellExecute") != std::string::npos) {
+                // Try lpParameters (arg 3) first
+                if (call->getNumArgOperands() > 3 && call->getArgOperand(3) && !isa<ConstantPointerNull>(call->getArgOperand(3))) {
+                    commandArgument = call->getArgOperand(3);
+                } else if (call->getNumArgOperands() > 1) { // Fallback to lpFile (arg 1)
+                    commandArgument = call->getArgOperand(1);
+                }
+              }
+              // Fallback if not specifically handled above, though most should be.
+              // The original simplified logic was "call->getArgOperand(1)".
+              // execl's "arg" (the actual command passed to the new program) is the second argument (index 1)
+              // if we consider `path` as the first.
+              // Let's refine for execl based on "For execl: It's the second argument (arg)."
+              else if (calledFuncNameStdStr == "execl") {
+                if (call->getNumArgOperands() > 1) commandArgument = call->getArgOperand(1);
+              }
+              // Defaulting to arg 0 if commandArgument is still null, for functions like execv where 'file' is appropriate.
+              else {
+                if (call->getNumArgOperands() > 0) commandArgument = call->getArgOperand(0);
+              }
+
+
+            } else { // Default for system, popen
+               if (call->getNumArgOperands() > 0) commandArgument = call->getArgOperand(0);
+            }
+
+
+            if (commandArgument) {
+              IRBuilder<> IRB(&I); // Build before the call instruction
+              Value *cmdArgForCheck = commandArgument;
+
+              // Ensure the argument is char*
+              if (cmdArgForCheck->getType() != CharStarTy) {
+                cmdArgForCheck = IRB.CreateBitCast(cmdArgForCheck, CharStarTy);
+              }
+
+              IRB.CreateCall(check_cmd_injection, {cmdArgForCheck})
+                  ->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
+            }
           }
-
         }
-
       }
-
     }
-
   }
 
   return PreservedAnalyses::all();
-
 }
 
 llvm::StringRef AFLDEMOPass::GetCallInsFunctionName(CallInst *call) {
@@ -128,8 +208,24 @@ llvm::StringRef AFLDEMOPass::GetCallInsFunctionName(CallInst *call) {
   } else {
 
     // Indirect call
-    return dyn_cast<Function>(call->getCalledOperand()->stripPointerCasts())
-        ->getName();
+    // Check if the called value is a function pointer casted from another type
+    Value* calledValue = call->getCalledOperand();
+    if (ConstantExpr* ce = dyn_cast<ConstantExpr>(calledValue)) {
+        if (ce->isCast()) {
+            if (Function* f = dyn_cast<Function>(ce->getOperand(0))) {
+                return f->getName();
+            }
+        }
+    }
+    // Fallback for other indirect calls, though this might still not cover all cases or might be risky
+    // The original code: dyn_cast<Function>(call->getCalledOperand()->stripPointerCasts())->getName();
+    // This can crash if stripPointerCasts() doesn't resolve to a Function.
+    // A safer approach is to return an empty StringRef or a placeholder if the name can't be resolved.
+    Value *strippedValue = call->getCalledOperand()->stripPointerCasts();
+    if (Function *f = dyn_cast<Function>(strippedValue)) {
+        return f->getName();
+    }
+    return ""; // Return empty if function name cannot be resolved
 
   }
 

--- a/llvm-pass/afl-demo-rt.o.c
+++ b/llvm-pass/afl-demo-rt.o.c
@@ -35,9 +35,29 @@
   #include "snapshot-inl.h"
 #endif
 
-void __demo_crash() {
+/*
+  Implement __afl_check_cmd_injection to detect metacharacters in a command string.
+  If a metacharacter is found, it prints an error message to stderr and calls abort().
+*/
+void __afl_check_cmd_injection(const char *command_string) {
 
-  fprintf(stderr, "system found!\n");
-  abort();
+  if (command_string == NULL) { return; }
 
+  // Metacharacters that could indicate command injection vulnerabilities.
+  // Note: '&' can appear in legitimate URLs. This is a known trade-off.
+  const char *metachars = ";|&`$()<>";
+
+  // Iterate through the command_string to check for any metacharacters.
+  // Using strpbrk for efficiency to find any character from metachars in command_string.
+  const char *found_char = strpbrk(command_string, metachars);
+
+  if (found_char != NULL) {
+    // A metacharacter was found.
+    fprintf(stderr,
+            "Potential command injection detected! Metacharacter '%c' found in command: %s\n",
+            *found_char, command_string);
+    abort(); // Terminate the program, allowing AFL++ to detect the crash.
+  }
+
+  // No metacharacters found, function returns normally.
 }


### PR DESCRIPTION
This commit introduces an LLVM pass and associated runtime library to detect potential command injection vulnerabilities.

The LLVM pass (`llvm-pass/afl-demo-pass.so.cc`) has been modified to:
- Identify a list of common command execution sink functions (e.g., `system`, `popen`, `exec*`, `ShellExecute*`, `CreateProcess*`).
- Instrument calls to these sink functions by inserting a call to a runtime checking function (`__afl_check_cmd_injection`) before the actual sink call.
- Pass the command string argument from the sink function to the runtime checker.

The runtime library (`llvm-pass/afl-demo-rt.o.c`) now includes:
- The `__afl_check_cmd_injection` function, which takes a command string.
- This function inspects the command string for common shell metacharacters (e.g., ';', '|', '&', '$', '`').
- If a metacharacter is found, it prints a warning message to stderr detailing the potential vulnerability and the offending command, and then calls `abort()`. This allows AFL++ to detect the issue as a crash.
- The previous `__demo_crash` function has been removed.

This setup aims to help AFL++ discover command injection vulnerabilities by instrumenting programs at the LLVM IR level and performing runtime checks on command strings.